### PR TITLE
Read-only "after" files

### DIFF
--- a/setup
+++ b/setup
@@ -3,3 +3,4 @@
 rm -rf player1 player2
 cp -R template player1
 cp -R template player2
+chmod 444 player{1,2}/*.after


### PR DESCRIPTION
Updates the setup script to flag the 1.after, 2.after, etc. files as
read-only, so Vim will display a warning when editing them. This is an
attempt to catch a racer's attention when they accidentally start editing
the after file.
